### PR TITLE
add: Lightning talk video (Japanese) for `Dart client for Genkit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ Genkit is a framework designed to help you build AI-powered applications and fea
 
 - [Supercharge your app with Genkit](https://www.youtube.com/watch?v=eVud8llb_W0) - A talk on how to supercharge your app with Genkit.
 - [Accelerating Generative AI App Development with Flutter & Genkit](https://speakerdeck.com/coborinai/accelerating-generative-ai-app-development-with-flutter-and-firebase-genkit) - Slides from a presentation at FlutterGakkai, a Flutter conference in Japan, showcasing how to integrate Genkit with Flutter for rapid generative AI app development.
-- [Dart client for Genkit: Call Genkit Flows from Flutter/Dart](https://speakerdeck.com/coborinai/dart) - Slides from a lightning talk at Google I/O Extended Tokyo 2025, introducing the Dart client library for calling Genkit flows from Flutter/Dart applications.
+- [Dart client for Genkit: Call Genkit Flows from Flutter/Dart - Slides](https://speakerdeck.com/coborinai/dart) - Slides from a lightning talk at Google I/O Extended Tokyo 2025, introducing the Dart client library for calling Genkit flows from Flutter/Dart applications.
+- [Dart client for Genkit: Call Genkit Flows from Flutter/Dart - Video](https://youtu.be/AakdczWQLzY?si=S5aT29miICHWQepM) - Video from a lightning talk at Google I/O Extended Tokyo 2025, introducing the Dart client library for calling Genkit flows from Flutter/Dart applications.
 
 ## Videos
 - [Getting started with Genkit/JS 1.0](https://www.youtube.com/watch?v=3p1P5grjXIQ) - Learn how to get started with Genkit/JS 1.0.


### PR DESCRIPTION
- Add YouTube video from Google I/O Extended Tokyo 2025
- Clarify Slides vs Video distinction in titles

## Review the Contributing Guidelines

Before submitting a pull request, verify it meets all requirements in the [Contributing Guidelines](https://github.com/tomhuang12/awesome-k8s-resources/blob/master/contributing.md).

## Describe The changes

This change is a:
[] Bug fix
[x] New awesome stuff
[] Documentation update
[] Other

Include a summary of the change and relevant motivation/context.

Like this pull request?  Vote for it by adding a :+1:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Talks" section in the README to provide separate links for the slides and video of the Dart client for Genkit lightning talk at Google I/O Extended Tokyo 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->